### PR TITLE
Fix tests when using git core.autcrlf=true on windows

### DIFF
--- a/src/test/java/org/telosys/tools/generator/engine/GeneratorEncodingTest.java
+++ b/src/test/java/org/telosys/tools/generator/engine/GeneratorEncodingTest.java
@@ -32,9 +32,9 @@ public class GeneratorEncodingTest {
 	@Test
 	public void testEncoding01() {
 		String s = generateFromTemplateFile(BUNDLE, "encoding-utf8-1.vm", getContext1());
-		String expected = 
-				  "abcdefghijk" + "\n"
-				+ "é è ê ë à ç ù" + "\n"
+		String expected =
+				  "abcdefghijk" + System.lineSeparator()
+				+ "é è ê ë à ç ù" + System.lineSeparator()
 				+ "name = éàùç";
 		assertEquals(expected, s);
 	}
@@ -43,7 +43,7 @@ public class GeneratorEncodingTest {
 	public void testEncoding02() {
 		String s = generateFromTemplateFile(BUNDLE, "encoding-utf8-2.vm", getContext2());
 		String expected = 
-				  " α β γ" + "\n"
+				  " α β γ" + System.lineSeparator()
 				+ "name = δεη";
 		assertEquals(expected, s);
 	}


### PR DESCRIPTION
Tests were failing on my windows machine due to line breaks being checked out as CRLF
I changed the tests so that they use the OS line break characters

Even though technically the default value for core.autocrlf is false, the windows installer for git picks true by default, and it is the recommended configuration for windows. On linux the default is false, and that is the recommended configuration for linux, I think using the OS line breaks should make the tests compatible with most environments